### PR TITLE
Update Socket.cs

### DIFF
--- a/Scripts/Unity-SocketIO/Socket.cs
+++ b/Scripts/Unity-SocketIO/Socket.cs
@@ -129,7 +129,7 @@ namespace KyleDulce.SocketIo {
                         value.Remove(callback);
                     }
                 } else {
-                    ActionEvents = new Dictionary<string, List<Action<string>>>();
+                    ActionEvents[ev] = new List<Action<string>>();
                 }           
             return this;
         }


### PR DESCRIPTION
Currently, when you call the `off` function with an event name `ev`, rather than removing all callbacks for the event `ev`, all the callbacks are removed from the socket. This change fixes the issue.